### PR TITLE
Custom windows starting with layers window

### DIFF
--- a/app/main.tsx
+++ b/app/main.tsx
@@ -38,14 +38,14 @@ view.when(() => {
     return ['Lots', 'Spaces'].indexOf(layer.title) > -1;
   }).forEach((layer) => { layer.visible = false });
 
+  // Create a laywer window that will be hidden until opened by a window expand
   const layersWindow = new CustomWindow({
     name: 'layers',
     widgets: [
       {
         label: "Layers",
         widget: new LayerList({
-          view: view,
-          container: document.createElement('div') as HTMLElement
+          view: view
         })
       }
     ]

--- a/app/widgets/CustomWindow.tsx
+++ b/app/widgets/CustomWindow.tsx
@@ -3,18 +3,21 @@ import { renderable, tsx } from "esri/widgets/support/widget";
 
 import Widget = require("esri/widgets/Widget");
 
-// Interface for anything with a render method
+// Interface for objects with a render method
 interface RenderableWidget {
   render: any;
 }
 
-// Interface for objects with widgets with labels
+// Interface for objects with widget and label properties
 interface WidgetWithLabel {
   label: string;
   widget: RenderableWidget;
 }
 
-// Return the current padding or margin in pixels of an element
+/*
+  Return the current padding or margin in pixels of an element assuming the
+  padding or margin is uniform on every side.
+*/
 function getElementStyleSize(element: Element, property: string): number {
   if (['padding', 'margin'].indexOf(property) > -1) {
     return Number(
@@ -28,7 +31,10 @@ function getElementStyleSize(element: Element, property: string): number {
 
 @subclass("esri.widgets.CustomWindow")
 class CustomWindow extends declared(Widget) {
-  // Used for id and title, and is referenced by a window expand
+  /*
+    Used for id and title, and is referenced by a window expand with the
+    same name.
+  */
   @property()
   @renderable()
   name: string;
@@ -45,7 +51,7 @@ class CustomWindow extends declared(Widget) {
 
   // Render this widget by returning JSX which is converted to HTML
   render() {
-    let renderedWidgets = [];
+    let renderedElements = [];
     /*
       Render each widget label pair in this window and put the result into
       an array.
@@ -54,12 +60,15 @@ class CustomWindow extends declared(Widget) {
       const widgetWithLabel = this.widgets[i];
       // Only render the label if it exists
       if (widgetWithLabel.label !== "") {
-        renderedWidgets.push(<p class="widget-label">{widgetWithLabel.label}</p>);
+        renderedElements.push(<p class="widget-label">{widgetWithLabel.label}</p>);
       }
-      renderedWidgets.push(widgetWithLabel.widget.render());
+      renderedElements.push(widgetWithLabel.widget.render());
     }
 
-    // Set the height of the main navigation widget
+    /*
+      Set the height of the main navigation widget so that the custom window
+      can scroll off the bottom of the screen properly.
+    */
     if (this._element()) {
       const mainNavigation = document.getElementById('main-navigation');
       if (this._mainNavigationHeight() + this._element().scrollHeight > window.innerHeight) {
@@ -71,19 +80,23 @@ class CustomWindow extends declared(Widget) {
       }
     }
 
+    const closeButton = (
+      <div
+        bind={this}
+        class="esri-widget esri-widget--button custom-window-close"
+        onclick={this._close}
+        title={`Close ${this.name}`}>
+        <span class={`esri-icon esri-icon-close`}></span>
+      </div>
+    );
+
     return (
       <div
         id={`${this.name}-window`}
         class="navigation-window custom-window"
         style={`max-height: calc(100% - ${this._mainNavigationHeight()}px)`}>
-        <div
-          bind={this}
-          class="esri-widget esri-widget--button custom-window-close"
-          onclick={this._close}
-          title={`Close ${this.name}`}>
-          <span class={`esri-icon esri-icon-close`}></span>
-        </div>
-        {renderedWidgets}
+        {closeButton}
+        {renderedElements}
       </div>
     );
   }
@@ -100,7 +113,7 @@ class CustomWindow extends declared(Widget) {
 
   /*
     Return the height of the main navigation widget in pixels not including
-    the size of this window.
+    the size of this custom window.
   */
   private _mainNavigationHeight(): number {
     const mainWindow = document.getElementById("main-navigation-window");

--- a/app/widgets/MainNavigation.tsx
+++ b/app/widgets/MainNavigation.tsx
@@ -50,7 +50,7 @@ class MainNavigation extends declared(Widget) {
   @renderable()
   search: Search;
 
-  // Custom windows that start hidden
+  // Custom windows that start hidden and can be opened by window expands
   @property()
   @renderable()
   customWindows: Array<CustomWindow>;
@@ -66,7 +66,10 @@ class MainNavigation extends declared(Widget) {
   // Render this widget by returning JSX which is converted to HTML
   render() {
     let renderedWindows = [];
-    // Render each custom window into an array
+    /*
+      Render each custom window into an array.
+      Only one window will be visible at a time.
+    */
     for (let i = 0; i < this.customWindows.length; i += 1) {
       renderedWindows.push(this.customWindows[i].render());
     }

--- a/app/widgets/WindowExpand.tsx
+++ b/app/widgets/WindowExpand.tsx
@@ -5,7 +5,10 @@ import Widget = require("esri/widgets/Widget");
 
 @subclass("esri.widgets.WindowExpand")
 class WindowExpand extends declared(Widget) {
-  // The name to reference a custom window by the same name
+  /*
+    The reference name used to open the corresponding custom window by the
+    same name.
+  */
   @property()
   @renderable()
   name: string;
@@ -15,10 +18,7 @@ class WindowExpand extends declared(Widget) {
   @renderable()
   iconName: string;
 
-  /*
-    Pass in properties as `any` type which will then be cast to
-    their correct types.
-  */
+  // Pass in a name and an icon name
   constructor(properties?: { name: string, iconName: string }) {
     super();
   }
@@ -36,11 +36,14 @@ class WindowExpand extends declared(Widget) {
     );
   }
 
-  // Open or close the custom window based on our name
+  /*
+    Referencing the custom window by the same name, open the window if it
+    is closed, and close the window if it is open.
+  */
   private _expand() {
     const attachedWindow = document.getElementById(`${this.name}-window`);
     if (attachedWindow.style.display === 'none') {
-      // Close any other custom windows first
+      // Close any other custom windows before opening this one
       const customWindows = document.getElementsByClassName('custom-window');
       for (let i = 0; i < customWindows.length; i += 1) {
         (customWindows[i] as HTMLElement).style.display = 'none';

--- a/index.css
+++ b/index.css
@@ -8,15 +8,15 @@ body,
 }
 
 .navigation-window {
-  font-family: "Avenir Next W00","Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-family: "Avenir Next W00", "Helvetica Neue", Helvetica, Arial, sans-serif;
   background-color: white;
   border: 0.2rem solid #881c1c;
   padding: 0.8rem;
   margin: 1rem;
-  overflow-y: auto;
 }
 
 .custom-window {
+  overflow-y: auto;
   display: none;
 }
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
   </head>
   <body>
     <div id="viewDiv"></div>
-    <div id="layersWindow"></div>
     <script>require(["app/main"]);</script>
   </body>
 </html>


### PR DESCRIPTION
This PR creates a generic `CustomWindow` widget that can be used for the layers, directions and share buttons. Right now for a start there is a layers window with the default layers widget, which we will replace later with our own custom layers widget. You can open/close the window by clicking on the corresponding `WindowExpand` widget in the main navigation window. You can close the window by pressing the `X` on the custom window.
With this setup only one window can be open at a time, which works especially well when you are on a phone. Opening another window will close the current one.

![screen shot 2019-02-20 at 2 59 53 pm](https://user-images.githubusercontent.com/7032019/53120801-a8479580-3520-11e9-823b-860389183ce0.png)
 