### PR TITLE
Browser compatibility

### DIFF
--- a/app/widgets/CustomDirections.tsx
+++ b/app/widgets/CustomDirections.tsx
@@ -40,7 +40,7 @@ class CustomDirections extends declared(Widget) {
             </select>
             <button
               bind={this}
-              class='button-right umass-theme-button'
+              class='right umass-theme-button'
               onclick={this._submit}
               type='submit'>
               Go

--- a/static/brand.css
+++ b/static/brand.css
@@ -171,8 +171,8 @@
     overflow: hidden;
     position: absolute;
     text-align: center;
-    left: 50vw;
-    top: 50vh;
+    left: 50%;
+    top: 50%;
     transform: translate(-50%,-50%);
     z-index: 3;
   }
@@ -191,8 +191,8 @@
     background: rgba(255,255,255,0.95);
     clip: auto;
     opacity: 1;
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
   }
 }
 

--- a/static/index.css
+++ b/static/index.css
@@ -39,6 +39,7 @@ body {
 }
 
 #main-navigation-window {
+  flex-shrink: 0;
   margin-bottom: 0;
 }
 

--- a/static/index.css
+++ b/static/index.css
@@ -225,10 +225,6 @@ input:focus {
   color: white !important;
 }
 
-.esri-attribution {
-  flex-shrink: 0;
-}
-
 .esri-icon,
 .esri-icon-search,
 .esri-icon-close,

--- a/static/index.css
+++ b/static/index.css
@@ -1,10 +1,16 @@
 html,
-body,
+body {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+}
+
 #viewDiv {
   padding: 0;
   margin: 0;
-  height: calc(100vh - 61px);
   width: 100%;
+  height: calc(100% - 61px);
 }
 
 #main-navigation {
@@ -51,6 +57,7 @@ body,
 }
 
 #filter-window {
+  flex-shrink: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -217,6 +224,10 @@ input:focus {
   color: white !important;
 }
 
+.esri-attribution {
+  flex-shrink: 0;
+}
+
 .esri-icon,
 .esri-icon-search,
 .esri-icon-close,
@@ -356,7 +367,7 @@ input:focus {
 
 .feedback {
   display: flex;
-  align-items: end;
+  align-items: flex-end;
 }
 .feedback-button {
   background-color: white;

--- a/static/index.html
+++ b/static/index.html
@@ -25,11 +25,6 @@
       if (/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
         // Browserify dependencies for promise compatibility
         document.write('<script src="bundle.js"><\/script>');
-        /*
-          `max-height: 100%` with `display: flex` doesn't work on IE, so instead
-          limit the height of custom windows to 30%.
-        */
-        document.write('<style>.custom-window { flex-basis: 30vh }<\/style>');
       }
     </script>
     <script src="https://js.arcgis.com/4.10"></script>

--- a/static/index.html
+++ b/static/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="brand.css">
     <link rel="stylesheet" href="index.css">
     <link rel="stylesheet" href="popup.css">
+    <link rel="shortcut icon" href="favicon.ico" />
     <script>
       // Current path minus everything after the last forward slash
       var locationPath = location.pathname.replace(/\/[^\/]*$/, "");

--- a/static/popup.css
+++ b/static/popup.css
@@ -79,10 +79,14 @@
     max-height: 40vh;
   }
   .custom-popup-container.docked {
+    flex-shrink: 0;
+    overflow: auto;
     width: 100vw;
+    height: 35%;
     margin-top: auto;
   }
   .custom-popup-container.docked .custom-popup {
+    height: 100%;
     border-right: 0;
     border-bottom: 0;
     border-left: 0;
@@ -90,6 +94,5 @@
     margin-top: 0;
     margin-left: 0;
     margin-right: 0;
-    max-height: 20vh;
   }
 }


### PR DESCRIPTION
* closes #81: Fix document size on Safari iOS where `vh` referred to a percentage of the screen height, not the height between the url bar and the bottom bar.
* Explicit favicon path, which will hopefully be relative to where the server is being hosted and not to the root, i.e. `maps.umass.edu/parking/beta/favicon.ico` rather than currently `maps.umass.edu/favicon.ico`.
* Because we are using `pointer-events: none` on the main navigation, it no longer matters that IE always has the navigation height at 100%, since it doesn't interfere with panning the map.
* closes #76: related to flexbox and `flex-shrink`