### PR TITLE
Search cleanup

### DIFF
--- a/app/CustomSearchSources.tsx
+++ b/app/CustomSearchSources.tsx
@@ -162,11 +162,18 @@ class CustomSearchSources extends declared(Accessor) {
 
   // Return a promise for location suggestions
   private _suggestLocations(searchTerm: string): Promise<Array<Suggestion>> {
-    const suggestPromises = [];
+    const suggestPromises: Array<IPromise<any>> = [];
+    let sources = CustomSearchSources.locationSearchSourceProperties;
+    // Dont use off campus locations unless this is an explicit location search
+    if (!this.locationsOnly) {
+      sources = sources.filter((source) => {
+        return source.title === 'On-campus locations';
+      });
+    }
     // Create a promise for every locator service
-    for (let i = 0; i < CustomSearchSources.locationSearchSourceProperties.length; i += 1) {
+    sources.forEach((source) => {
       suggestPromises.push(esriRequest(
-        CustomSearchSources.locationSearchSourceProperties[i].url + '/suggest',
+        source.url + '/suggest',
         {
           query: {
             text: searchTerm,
@@ -177,7 +184,7 @@ class CustomSearchSources extends declared(Accessor) {
           }
         }
       ));
-    }
+    });
     // Resolve all promises with their results as an array in order
     return Promise.all(suggestPromises).then((responses) => {
       const suggestions: Array<Suggestion> = [];

--- a/app/CustomSearchSources.tsx
+++ b/app/CustomSearchSources.tsx
@@ -8,7 +8,7 @@ import MapView = require('esri/views/MapView');
 
 import { umassLongLat } from 'app/latLong';
 import { toNativePromise } from 'app/promises';
-import { filterInfo, departmentInfo } from 'app/rendering';
+import { filterInfo } from 'app/rendering';
 import {
   SearchSourceType,
   SearchFilter,
@@ -55,8 +55,6 @@ class CustomSearchSources extends declared(Accessor) {
       return 'Filters';
     } else if (suggestion.sourceType === SearchSourceType.Space) {
       return 'Spaces';
-    } else if (suggestion.sourceType === SearchSourceType.Department) {
-      return 'Departments';
     } else {
       return '';
     }
@@ -70,7 +68,6 @@ class CustomSearchSources extends declared(Accessor) {
       suggestPromises = [this._suggestLocations(searchTerm)];
     } else {
       suggestPromises = [
-        this._suggestDepartments(searchTerm),
         this._suggestFilters(searchTerm),
         this._suggestSpaces(searchTerm),
         this._suggestLocations(searchTerm)
@@ -141,18 +138,6 @@ class CustomSearchSources extends declared(Accessor) {
         filter: suggestion.filter
       }
       return Promise.resolve(searchResult);
-    // Search for departments
-    } else if (suggestion.sourceType == SearchSourceType.Department) {
-      const department = departmentInfo.filter((department) => {
-        return department.name === suggestion.text;
-      })[0];
-      searchResult = {
-        name: suggestion.text,
-        sourceType: SearchSourceType.Department,
-        latitude: department.latitude,
-        longitude: department.longitude,
-      };
-      return Promise.resolve(searchResult);
     } else {
       return Promise.reject(
         `Cannot search for suggestion from source type ${suggestion.sourceType}`
@@ -162,18 +147,11 @@ class CustomSearchSources extends declared(Accessor) {
 
   // Return a promise for location suggestions
   private _suggestLocations(searchTerm: string): Promise<Array<Suggestion>> {
-    const suggestPromises: Array<IPromise<any>> = [];
-    let sources = CustomSearchSources.locationSearchSourceProperties;
-    // Dont use off campus locations unless this is an explicit location search
-    if (!this.locationsOnly) {
-      sources = sources.filter((source) => {
-        return source.title === 'On-campus locations';
-      });
-    }
+    const suggestPromises = [];
     // Create a promise for every locator service
-    sources.forEach((source) => {
+    for (let i = 0; i < CustomSearchSources.locationSearchSourceProperties.length; i += 1) {
       suggestPromises.push(esriRequest(
-        source.url + '/suggest',
+        CustomSearchSources.locationSearchSourceProperties[i].url + '/suggest',
         {
           query: {
             text: searchTerm,
@@ -184,7 +162,7 @@ class CustomSearchSources extends declared(Accessor) {
           }
         }
       ));
-    });
+    }
     // Resolve all promises with their results as an array in order
     return Promise.all(suggestPromises).then((responses) => {
       const suggestions: Array<Suggestion> = [];
@@ -205,28 +183,6 @@ class CustomSearchSources extends declared(Accessor) {
     }).catch((error) => {
       throw error;
     });
-  }
-
-  private _suggestDepartments(searchTerm: string): Promise<Array<Suggestion>> {
-    const maxResults = 5;
-    const suggestions: Array<Suggestion> = [];
-    departmentInfo.forEach((department: any) => {
-      if (suggestions.length >= maxResults) {
-        return;
-      }
-      /*
-        Only include the department as a suggestion if the search term matches
-        the department's tags.
-      */
-      if (searchTermMatchesTags(searchTerm, department.tags)) {
-        suggestions.push({
-          text: department.name,
-          key: `department-${department.name}`,
-          sourceType: SearchSourceType.Department
-        });
-      }
-    });
-    return Promise.resolve(suggestions);
   }
 
   // Return a promise for filter suggestions

--- a/app/main.tsx
+++ b/app/main.tsx
@@ -102,13 +102,15 @@ view.when(() => {
       view: view,
       name: 'pedestrian-directions-origin',
       placeholder: 'Origin',
-      required: true
+      required: true,
+      onCampusLocationsOnly: true
     }),
     new CustomSearch({
       view: view,
       name: 'pedestrian-directions-destination',
       placeholder: 'Destination',
-      required: true
+      required: true,
+      onCampusLocationsOnly: true
     })
   ];
 

--- a/app/main.tsx
+++ b/app/main.tsx
@@ -69,6 +69,10 @@ view.when(() => {
   (map.layers.find((layer) => {
     return layer.title === 'Sections';
   }) as FeatureLayer).maxScale = 500;
+  // Ensure spaces show up when zoomed out to the whole campus
+  (map.layers.find((layer) => {
+    return layer.title === 'Spaces';
+  }) as FeatureLayer).minScale = 75000;
 
   // Set custom icons in the layer renderers
   updateRenderers(map);

--- a/app/rendering.tsx
+++ b/app/rendering.tsx
@@ -141,7 +141,7 @@ const sectionRendererInfo = {
   }
 }
 
-const _filterInfo: Array<SearchFilter> = [
+const filterInfo: Array<SearchFilter> = [
   {
     name: 'Metered/Visitor Parking',
     description: 'Locations to park without a permit. Pay at a meter or a paystation.',
@@ -178,16 +178,25 @@ const _filterInfo: Array<SearchFilter> = [
   }
 ];
 
+// Add lot search filters
 ['Red', 'Blue', 'Purple', 'Yellow', 'Green'].forEach((color) => {
-  _filterInfo.push({
+  filterInfo.push({
     name: `${color} Lots`,
     tags: [color],
     visible: true,
     clauses: [{layerName: 'Sections', clause: `SectionColor = '${color}'`}]
   });
 });
-// For simplicity we should never be modifying filterInfo outside of this file
-const filterInfo = _filterInfo;
+
+// Add space search filters
+Object.keys(spaceRendererInfo).forEach((spaceCategory) => {
+  filterInfo.push({
+    name: spaceRendererInfo[spaceCategory].label,
+    tags: spaceRendererInfo[spaceCategory].label.split(' '),
+    visible: true,
+    clauses: [{layerName: 'Spaces', clause: `ParkingSpaceSubCategory = '${spaceCategory}'`}]
+  });
+});
 
 // Update the renderers of layers to add our own icons
 function updateRenderers(map: WebMap): void {

--- a/app/rendering.tsx
+++ b/app/rendering.tsx
@@ -141,7 +141,7 @@ const sectionRendererInfo = {
   }
 }
 
-const _filterInfo: Array<SearchFilter> = [
+const filterInfo: Array<SearchFilter> = [
   {
     name: 'Metered/Visitor Parking',
     description: 'Locations to park without a permit. Pay at a meter or a paystation.',
@@ -179,15 +179,22 @@ const _filterInfo: Array<SearchFilter> = [
 ];
 
 ['Red', 'Blue', 'Purple', 'Yellow', 'Green'].forEach((color) => {
-  _filterInfo.push({
+  filterInfo.push({
     name: `${color} Lots`,
     tags: [color],
     visible: true,
     clauses: [{layerName: 'Sections', clause: `SectionColor = '${color}'`}]
   });
 });
-// For simplicity we should never be modifying filterInfo outside of this file
-const filterInfo = _filterInfo;
+
+const departmentInfo: Array<any> = [
+  {
+    name: 'Parking Services',
+    tags: ['parking', 'services'],
+    latitude: 42.39256,
+    longitude: -72.53520,
+  }
+];
 
 // Update the renderers of layers to add our own icons
 function updateRenderers(map: WebMap): void {
@@ -449,6 +456,7 @@ export {
   spaceRendererInfo,
   sectionRendererInfo,
   filterInfo,
+  departmentInfo,
   goToSmart,
   imperialDistance,
   attributeRow,

--- a/app/rendering.tsx
+++ b/app/rendering.tsx
@@ -141,7 +141,7 @@ const sectionRendererInfo = {
   }
 }
 
-const filterInfo: Array<SearchFilter> = [
+const _filterInfo: Array<SearchFilter> = [
   {
     name: 'Metered/Visitor Parking',
     description: 'Locations to park without a permit. Pay at a meter or a paystation.',
@@ -179,22 +179,15 @@ const filterInfo: Array<SearchFilter> = [
 ];
 
 ['Red', 'Blue', 'Purple', 'Yellow', 'Green'].forEach((color) => {
-  filterInfo.push({
+  _filterInfo.push({
     name: `${color} Lots`,
     tags: [color],
     visible: true,
     clauses: [{layerName: 'Sections', clause: `SectionColor = '${color}'`}]
   });
 });
-
-const departmentInfo: Array<any> = [
-  {
-    name: 'Parking Services',
-    tags: ['parking', 'services'],
-    latitude: 42.39256,
-    longitude: -72.53520,
-  }
-];
+// For simplicity we should never be modifying filterInfo outside of this file
+const filterInfo = _filterInfo;
 
 // Update the renderers of layers to add our own icons
 function updateRenderers(map: WebMap): void {
@@ -456,7 +449,6 @@ export {
   spaceRendererInfo,
   sectionRendererInfo,
   filterInfo,
-  departmentInfo,
   goToSmart,
   imperialDistance,
   attributeRow,

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -4,13 +4,14 @@ import Graphic = require('esri/Graphic');
 enum SearchSourceType {
   Location = 0,
   Filter = 1,
-  Space = 2
+  Space = 2,
+  Department = 3,
 }
 
 interface SearchFilterClause {
   layerName: string;
   clause?: string;
-  labelsVisible?: boolean,
+  labelsVisible?: boolean;
 }
 
 interface SearchFilter {

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -4,14 +4,13 @@ import Graphic = require('esri/Graphic');
 enum SearchSourceType {
   Location = 0,
   Filter = 1,
-  Space = 2,
-  Department = 3,
+  Space = 2
 }
 
 interface SearchFilterClause {
   layerName: string;
   clause?: string;
-  labelsVisible?: boolean;
+  labelsVisible?: boolean,
 }
 
 interface SearchFilter {

--- a/app/widgets/CustomSearch.tsx
+++ b/app/widgets/CustomSearch.tsx
@@ -87,7 +87,8 @@ class CustomSearch extends declared(Widget) {
     placeholder: string,
     customFilter?: CustomFilter,
     required?: boolean,
-    mainSearch?: boolean
+    mainSearch?: boolean,
+    onCampusLocationsOnly?: boolean,
   }) {
     super();
     this.suggestions = [];
@@ -97,7 +98,9 @@ class CustomSearch extends declared(Widget) {
     this.mainSearch = properties.mainSearch || false;
     this.warning = '';
     this.sources = new CustomSearchSources({
-      view: properties.view, locationsOnly: !properties.mainSearch
+      view: properties.view,
+      locationsOnly: !properties.mainSearch,
+      onCampusLocationsOnly: properties.onCampusLocationsOnly,
     });
 
     // Hide suggestions when the escape key is pressed

--- a/app/widgets/CustomSearch.tsx
+++ b/app/widgets/CustomSearch.tsx
@@ -363,10 +363,7 @@ class CustomSearch extends declared(Widget) {
   // Called when the main search is submitted
   private _submitSearch(): boolean {
     if (this.searchResult) {
-      if (
-        this.searchResult.sourceType === SearchSourceType.Location ||
-        this.searchResult.sourceType === SearchSourceType.Department
-      ) {
+      if (this.searchResult.sourceType === SearchSourceType.Location) {
         // Go to a location result
         this.view.goTo({
           target: [this.searchResult.longitude, this.searchResult.latitude],

--- a/app/widgets/CustomSearch.tsx
+++ b/app/widgets/CustomSearch.tsx
@@ -123,18 +123,21 @@ class CustomSearch extends declared(Widget) {
     const visitedSources: Array<string> = [];
     if (this.showSuggestions) {
       this.suggestions.forEach((suggestion, i) => {
-        const header = this.sources.suggestionHeader(suggestion);
-        // Push a source header if the suggestions are from a new source
-        if (visitedSources.indexOf(header) === -1) {
-          visitedSources.push(header);
-          suggestionElements.push(
-            <div
-              class='custom-search-header suggestion-item'
-              key={`${suggestion.key}-header`}
-              role='heading'>
-              {header}
-            </div>
-          );
+        // No headers for the main search
+        if (!this.mainSearch) {
+          const header = this.sources.suggestionHeader(suggestion);
+          // Push a source header if the suggestions are from a new source
+          if (visitedSources.indexOf(header) === -1) {
+            visitedSources.push(header);
+            suggestionElements.push(
+              <div
+                class='custom-search-header suggestion-item'
+                key={`${suggestion.key}-header`}
+                role='heading'>
+                {header}
+              </div>
+            );
+          }
         }
         // Push a new suggestion
         suggestionElements.push(
@@ -161,15 +164,27 @@ class CustomSearch extends declared(Widget) {
             Loading...
           </div>
         );
-      }
       // Push error text
-      if (this.error) {
+      } else if (this.error) {
         suggestionElements.push(
           <div
             class='custom-search-header suggestion-item'
             key='error-header'
             role='heading'>
             Error loading suggestions. Please try again later.
+          </div>
+        );
+      // Push no results text
+      } else if (
+        this.suggestions.length === 0 &&
+        this._inputElement().value !== ''
+      ) {
+        suggestionElements.push(
+          <div
+            class='custom-search-header suggestion-item'
+            key='no-results-header'
+            role='heading'>
+            No Results.
           </div>
         );
       }

--- a/app/widgets/CustomSearch.tsx
+++ b/app/widgets/CustomSearch.tsx
@@ -348,7 +348,10 @@ class CustomSearch extends declared(Widget) {
   // Called when the main search is submitted
   private _submitSearch(): boolean {
     if (this.searchResult) {
-      if (this.searchResult.sourceType === SearchSourceType.Location) {
+      if (
+        this.searchResult.sourceType === SearchSourceType.Location ||
+        this.searchResult.sourceType === SearchSourceType.Department
+      ) {
         // Go to a location result
         this.view.goTo({
           target: [this.searchResult.longitude, this.searchResult.latitude],


### PR DESCRIPTION
* For any filter, if there is no geometry given to zoom to, it will automatically zoom to the union of the full extent of each layer (as in to what features are visible on all layers).
* Removed off campus locations for all searches except for driving directions (since you might be driving to or from off campus)
* Space search (eg search for all electric vehicle spaces)
* Removed headers from the main search, since all items in the search do essentially the same thing now which is bring you to the location of the thing you searched.