### PR TITLE
Don't render point geometry as a selection

### DIFF
--- a/app/widgets/CustomPopup.tsx
+++ b/app/widgets/CustomPopup.tsx
@@ -440,7 +440,10 @@ class CustomPopup extends declared(Widget) {
     }) as GraphicsLayer;
     selectionLayer.removeAll();
 
+    // Don't render a selection if this popup is closed
     if (!this.visible) return;
+    // Don't try to render a selection for point geometry
+    if (this.features[this.page].geometry.type === 'point') return;
 
     const graphic = this.features[this.page].clone();
     graphic.symbol = new SimpleFillSymbol({


### PR DESCRIPTION
closes #130 

This was caused by the upgrade from 4.10 to 4.12 API. Before we were adding point geometry with fill symbols (doesn't make sense). In the old API nothing bad happened, but in 4.12 we got that bug.