### PR TITLE
Open a generic popup when a search result is set in the main search

### DIFF
--- a/app/rendering.tsx
+++ b/app/rendering.tsx
@@ -462,6 +462,8 @@ function featureTitle(feature: Graphic): string {
     title = feature.attributes.Building_Name;
   } else if (feature.layer.title === 'Spaces') {
     title = spaceRendererInfo[feature.attributes.ParkingSpaceSubCategory].description;
+  } else if (feature.layer.title === 'Generic') {
+    title = feature.attributes.name;
   }
   return title;
 }

--- a/app/widgets/CustomPopup.tsx
+++ b/app/widgets/CustomPopup.tsx
@@ -358,7 +358,7 @@ class CustomPopup extends declared(Widget) {
             }
           }
         });
-        // Only open the popup if any features were returned
+        // Open popup only if any of the layer queries returned features
         if (this.features.length > 0) {
           this._open(pointParams.goTo);
         }

--- a/app/widgets/CustomPopup.tsx
+++ b/app/widgets/CustomPopup.tsx
@@ -246,6 +246,21 @@ class CustomPopup extends declared(Widget) {
     this._updateSelectionGraphic();
   }
 
+  // Open a generic popup for some text at a location
+  public openFromGeneric(
+    name: string, latitude: number, longitude: number
+  ): void {
+    this.reset();
+    this.point = new Point({ latitude: latitude, longitude: longitude });
+    const layer = new FeatureLayer({ title: 'Generic' });
+    this.features = [
+      new Graphic({
+        geometry: this.point, layer: layer, attributes: { name: name }
+      })
+    ]
+    this._open(true, 18);
+  }
+
   // Update the popup widget based on a mouse click event
   public openFromMouseClick(event: any): void {
     this._queryAndUseFeatures(
@@ -292,6 +307,7 @@ class CustomPopup extends declared(Widget) {
     );
   }
 
+  // Open a section popup using a citation location id
   public openFromCitationLocationId(id: string): void {
     this._queryAndUseFeatures(
       ['Sections'],
@@ -342,13 +358,9 @@ class CustomPopup extends declared(Widget) {
             }
           }
         });
-        // Open popup only if any of the layer queries returned features
+        // Only open the popup if any features were returned
         if (this.features.length > 0) {
-          this._open();
-          // Make the view go to where the popup was opened if requested
-          if (pointParams.goTo) {
-            this.view.goTo(this.point);
-          }
+          this._open(pointParams.goTo);
         }
         return;
       }).catch((error: string) => {
@@ -361,9 +373,17 @@ class CustomPopup extends declared(Widget) {
   }
 
   // Open the popup
-  private _open(): void {
+  private _open(goTo?: boolean, zoom?: number): void {
     this.visible = true;
     this._setDirection();
+    // Make the view go to where the popup was opened if requested
+    if (goTo) {
+      const target: any = { target: this.point };
+      if (zoom) {
+        target.zoom = zoom;
+      }
+      this.view.goTo(target);
+    }
   }
 
   // Go to the next page or feature
@@ -530,6 +550,8 @@ class CustomPopup extends declared(Widget) {
       return this._renderBuilding(feature);
     } else if (feature.layer.title === 'Spaces') {
       return this._renderSpace(feature);
+    } else if (feature.layer.title === 'Generic') {
+      return this._renderGeneric(feature);
     }
     return null;
   }
@@ -777,6 +799,14 @@ class CustomPopup extends declared(Widget) {
       <div key={feature.layer.title + feature.attributes.OBJECTID_1}>
         <h1>{featureTitle(feature)}{icon}</h1>
         {reserved}{payment}{duration}
+      </div>
+    );
+  }
+
+  private _renderGeneric(feature: Graphic): JSX.Element {
+    return (
+      <div key={feature.layer.title + feature.attributes.name}>
+        <h1>{featureTitle(feature)}</h1>
       </div>
     );
   }

--- a/app/widgets/MainNavigation.tsx
+++ b/app/widgets/MainNavigation.tsx
@@ -158,7 +158,8 @@ class MainNavigation extends declared(Widget) {
       name: 'main',
       placeholder: 'Search the map',
       customFilter: customFilter,
-      mainSearch: true
+      mainSearch: true,
+      popup: properties.popup,
     });
     this.layersExpand = new WindowExpand({
       name: 'layers',


### PR DESCRIPTION
closes #137 

This opens a generic popup for the search result that just has the search result text. Hopefully it will be clearer where the search result is now. We can't do the full popup because search results don't specify which feature on which layer is being returned.

<img width="682" alt="Screen Shot 2019-12-06 at 11 59 01 AM" src="https://user-images.githubusercontent.com/7032019/70340946-cff1bb00-181f-11ea-98df-f28ba55e9a01.png">
