### PR TITLE
Use my location

### DIFF
--- a/app/CustomSearchSources.tsx
+++ b/app/CustomSearchSources.tsx
@@ -181,7 +181,8 @@ class CustomSearchSources extends declared(Accessor) {
           };
           return searchResult;
         } else {
-          throw `Could not find search result for suggestion with magicKey ${suggestion.key}`;
+          throw `Failed to find result for suggestion. (Key ${suggestion.key}). ` +
+            'Try a different query.'
         }
       }).catch((error) => {
         throw error;
@@ -218,12 +219,13 @@ class CustomSearchSources extends declared(Accessor) {
           };
           resolve(searchResult);
         }, () => {
-          reject('Could not find your location');
+          reject('Could not find your location. Try a different query.');
         });
       });
     } else {
       return Promise.reject(
-        `Cannot search for suggestion from source type ${suggestion.sourceType}`
+        `Failed to find result for suggestion (Type ${suggestion.sourceType}). ` +
+        'Try a different query.'
       );
     }
   }

--- a/app/latLong.tsx
+++ b/app/latLong.tsx
@@ -49,8 +49,22 @@ function circleAt(screenPoint: ScreenPoint, view: MapView): Polygon {
   return circle;
 }
 
+// Return a promise to the location of the client using the geolocation api
+function myLocation(): Promise<Point> {
+  return new Promise((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition((location) => {
+      resolve(new Point({
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude
+      }));
+    }, () => {
+      reject('Could not find your location. Try a different query.');
+    });
+  });
+}
+
 /*
   Export helper functions related to positioning so they can be
   imported and used in other files.
 */
-export { umassLongLat, ScreenPoint, homeGoToOverride, circleAt };
+export { umassLongLat, ScreenPoint, homeGoToOverride, circleAt, myLocation };

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -7,6 +7,7 @@ enum SearchSourceType {
   Space = 2,
   // Used to supplement Location searches with better results
   Building = 3,
+  MyLocation = 4,
 }
 
 interface SearchFilterClause {

--- a/app/url.tsx
+++ b/app/url.tsx
@@ -155,6 +155,11 @@ function safeUrl(): string {
   return `${startUrl}${endUrl}`;
 }
 
+// Return true if the url is http not including localhost
+function isUrlInsecure(): boolean {
+  return location.protocol === 'http:' && location.hostname !== 'localhost';
+}
+
 /*
   Export helper functions related to urls so they can be
   imported and used in other files.
@@ -164,5 +169,6 @@ export {
   resetUrlTimer,
   updateAppFromUrl,
   safeUrl,
+  isUrlInsecure,
   rootUrl
 };

--- a/app/widgets/CustomLocate.tsx
+++ b/app/widgets/CustomLocate.tsx
@@ -1,0 +1,74 @@
+import { subclass, declared, property } from 'esri/core/accessorSupport/decorators';
+import { tsx } from 'esri/widgets/support/widget';
+
+import MapView = require('esri/views/MapView');
+import Widget = require('esri/widgets/Widget');
+
+import { myLocation } from 'app/latLong';
+import { iconButton } from 'app/rendering';
+import { isUrlInsecure } from 'app/url';
+
+import CustomPopup = require('app/widgets/CustomPopup');
+
+@subclass('esri.widgets.CustomLocate')
+class CustomLocate extends declared(Widget) {
+  // The map view
+  @property()
+  private readonly view: MapView;
+
+  // The popup to open when location is found
+  @property()
+  private readonly popup: CustomPopup;
+
+  // Whether or not this widget is disabled
+  @property()
+  private readonly disabled: boolean;
+
+  // Pass in properties
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public constructor(properties?: { view: MapView, popup: CustomPopup }) {
+    super();
+
+    // The geolocation api only works on secure connections
+    this.disabled = isUrlInsecure();
+  }
+
+  // Render this widget by returning JSX which is converted to HTML
+  public render(): JSX.Element {
+    const classes = [];
+    let name = 'Find my location';
+    if (this.disabled) {
+      classes.push('disabled');
+      name = 'Find my location disabled over insecure connection';
+    }
+    return iconButton({
+      object: this,
+      onclick: this._locate,
+      name: name,
+      iconName: 'locate',
+      classes: classes
+    });
+  }
+
+  // Called when this widget is clicked
+  private _locate(): void {
+    if (this.disabled) return;
+
+    myLocation().then((location) => {
+      this.popup.openFromGeneric(
+        'My location',
+        location.latitude,
+        location.longitude
+      );
+      return;
+    }).catch((error) => {
+      console.error(error);
+    });
+  }
+}
+
+/*
+  Export the custom locate widget so it can be imported and used in other
+  files.
+*/
+export = CustomLocate;

--- a/app/widgets/CustomSearch.tsx
+++ b/app/widgets/CustomSearch.tsx
@@ -64,6 +64,11 @@ class CustomSearch extends declared(Widget) {
   @renderable()
   private error: boolean;
 
+  // The error message to display when error is true
+  @property()
+  @renderable()
+  private errorMessage: string;
+
   // The warning to show related to the search input
   @property()
   @renderable()
@@ -169,14 +174,18 @@ class CustomSearch extends declared(Widget) {
             Loading...
           </div>
         );
-      // Push error text
+      // Push error message
       } else if (this.error) {
+        let errorMessage = 'Error loading suggestions. Please try again later.';
+        if (this.errorMessage) {
+          errorMessage = this.errorMessage;
+        }
         suggestionElements.push(
           <div
             class='custom-search-header suggestion-item'
             key='error-header'
             role='heading'>
-            Error loading suggestions. Please try again later.
+            {errorMessage}
           </div>
         );
       // Push no results text
@@ -407,6 +416,7 @@ class CustomSearch extends declared(Widget) {
       return;
     }
     this.error = false;
+    this.errorMessage = '';
     this.loadingSuggestions = true;
     // Safely find new suggestions
     this.suggestionRequestSet.setPromise(this.sources.suggest(searchTerm))
@@ -436,6 +446,7 @@ class CustomSearch extends declared(Widget) {
       console.error(error);
       this._clearSearch();
       this.error = true;
+      this.errorMessage = error;
     });
   }
 

--- a/app/widgets/CustomSearch.tsx
+++ b/app/widgets/CustomSearch.tsx
@@ -367,7 +367,8 @@ class CustomSearch extends declared(Widget) {
     if (this.searchResult) {
       if (
         this.searchResult.sourceType === SearchSourceType.Location ||
-        this.searchResult.sourceType === SearchSourceType.Building
+        this.searchResult.sourceType === SearchSourceType.Building ||
+        this.searchResult.sourceType === SearchSourceType.MyLocation
       ) {
         // Open and go to a generic popup for this result
         this.popup.openFromGeneric(

--- a/app/widgets/MainNavigation.tsx
+++ b/app/widgets/MainNavigation.tsx
@@ -4,7 +4,6 @@ import { tsx } from 'esri/widgets/support/widget';
 import MapView = require('esri/views/MapView');
 import BasemapToggle = require('esri/widgets/BasemapToggle');
 import Home = require('esri/widgets/Home');
-import Locate = require('esri/widgets/Locate');
 import Widget = require('esri/widgets/Widget');
 
 import { homeGoToOverride } from 'app/latLong';
@@ -14,6 +13,7 @@ import { resetUrlTimer } from 'app/url';
 import CustomDirections = require('app/widgets/CustomDirections');
 import CustomFilter = require('app/widgets/CustomFilter');
 import CustomLayerList = require('app/widgets/CustomLayerList');
+import CustomLocate = require('app/widgets/CustomLocate');
 import CustomSearch = require('app/widgets/CustomSearch');
 import CustomPedestrianDirections = require('app/widgets/CustomPedestrianDirections');
 import CustomPopup = require('app/widgets/CustomPopup');
@@ -182,7 +182,7 @@ class MainNavigation extends declared(Widget) {
         view: properties.view,
         goToOverride: homeGoToOverride
       }),
-      new Locate({ view: properties.view }),
+      new CustomLocate({ view: properties.view, popup: properties.popup }),
       this.layersExpand,
       new WindowExpand({
         name: 'directions',

--- a/static/index.css
+++ b/static/index.css
@@ -220,6 +220,13 @@ h2 {
   background-color: #333333 !important;
 }
 
+.esri-widget--button.disabled,
+.esri-widget--button.disabled:focus {
+  background-color: #bbbbbb !important;
+  cursor: default;
+  outline: none;
+}
+
 .custom-search-suggestion:focus,
 .esri-widget--button:focus,
 .esri-button:focus,


### PR DESCRIPTION
closes #63

Now you can search for "my" or "me" and "My location" will show up as a suggestion. Clicking it takes you to the point, with a popup saying "My location" in the same way as when you click on any other location suggestion.

I also made the Locate widget consistent with that described above with a new CustomLocate. This widget will appear disabled over insecure connections instead of just disappearing like it does now.