### PR TITLE
Looking for spaces UI

### DIFF
--- a/app/CustomSearchSources.tsx
+++ b/app/CustomSearchSources.tsx
@@ -411,7 +411,8 @@ class CustomSearchSources extends declared(Accessor) {
               {
                 layerName: 'Spaces',
                 clause: `ParkingSpaceClientPublic = '${escapeQueryParam(client)}'`
-              }
+              },
+              {layerName: 'Sections', clause: '0 = 1'}
             ],
             target: target
           };

--- a/app/rendering.tsx
+++ b/app/rendering.tsx
@@ -210,7 +210,13 @@ Object.keys(spaceRendererInfo).forEach((spaceCategory) => {
     tags: spaceRendererInfo[spaceCategory].label.split(' '),
     visible: true,
     showInFilterList: false,
-    clauses: [{layerName: 'Spaces', clause: `ParkingSpaceSubCategory = '${spaceCategory}'`}]
+    clauses: [
+      {layerName: 'Sections', clause: '0 = 1'},
+      {
+        layerName: 'Spaces',
+        clause: `ParkingSpaceSubCategory = '${spaceCategory}'`
+      }
+    ]
   });
 });
 

--- a/app/widgets/CustomPopup.tsx
+++ b/app/widgets/CustomPopup.tsx
@@ -478,7 +478,7 @@ class CustomPopup extends declared(Widget) {
 
     const graphic = this.features[this.page].clone();
     graphic.symbol = new SimpleFillSymbol({
-      color: '#e6f2ff',
+      color: [255, 255, 255, 0.8],
       outline: new SimpleLineSymbol({
         color: '#99ccff',
         width: '3px'


### PR DESCRIPTION
This makes it so that space searches don't show sections, which often get in the way since a section will always show up first in the popup.

Also, when someone does click on a section, they will still be able to see the spaces beneath since the selection is partially transparent:
<img width="408" alt="Screen Shot 2020-01-31 at 2 47 52 PM" src="https://user-images.githubusercontent.com/7032019/73570033-93b29380-4439-11ea-94ea-0606efe8f6b6.png">
