### PR TITLE
Fix bug in IE where filter window title would go off the side

### DIFF
--- a/app/rendering.tsx
+++ b/app/rendering.tsx
@@ -409,7 +409,7 @@ function expandable(
   mainElement: JSX.Element
 ): JSX.Element {
   return (
-    <div>
+    <div class='expandable-container'>
       <div
         aria-expanded={startExpanded ? 'true' : 'false'}
         aria-label={startExpanded ? `Collapse ${title}` : `Expand ${title}`}

--- a/static/index.css
+++ b/static/index.css
@@ -110,6 +110,10 @@ body {
   color: white;
 }
 
+.expandable-container {
+  flex-basis: 100%;
+}
+
 .expandable {
   cursor: pointer;
   display: flex;


### PR DESCRIPTION
This was supposed to be the commit that fixed #149, just forgot to commit