### PR TITLE
Object id refactor

### DIFF
--- a/app/CustomSearchSources.tsx
+++ b/app/CustomSearchSources.tsx
@@ -419,7 +419,7 @@ class CustomSearchSources extends declared(Accessor) {
           // Add the suggestion
           suggestions.push({
             text: `${client} Spaces`,
-            key: feature.attributes.OBJECTID_1,
+            key: String(feature.getObjectId()),
             sourceType: SearchSourceType.Space,
             filter: filter
           });

--- a/app/data.tsx
+++ b/app/data.tsx
@@ -58,9 +58,4 @@ function getSectionData(): any {
   Export helper functions related to raw data so they can be
   imported and used in other files.
 */
-export {
-  updateHubData,
-  getHubData,
-  updateSectionData,
-  getSectionData
-};
+export { updateHubData, getHubData, updateSectionData, getSectionData };

--- a/app/data.tsx
+++ b/app/data.tsx
@@ -54,14 +54,6 @@ function getSectionData(): any {
   return sectionData;
 }
 
-// Return a hardcoded object id based on layer name
-function objectIdColumn(layerName: string): string {
-  if (layerName === 'Campus Buildings') {
-    return 'OBJECTID';
-  }
-  return 'OBJECTID_1';
-}
-
 /*
   Export helper functions related to raw data so they can be
   imported and used in other files.
@@ -70,6 +62,5 @@ export {
   updateHubData,
   getHubData,
   updateSectionData,
-  getSectionData,
-  objectIdColumn
+  getSectionData
 };

--- a/app/data.tsx
+++ b/app/data.tsx
@@ -54,8 +54,22 @@ function getSectionData(): any {
   return sectionData;
 }
 
+// Return a hardcoded object id based on layer name
+function objectIdColumn(layerName: string): string {
+  if (layerName === 'Campus Buildings') {
+    return 'OBJECTID';
+  }
+  return 'OBJECTID_1';
+}
+
 /*
   Export helper functions related to raw data so they can be
   imported and used in other files.
 */
-export { updateHubData, getHubData, updateSectionData, getSectionData };
+export {
+  updateHubData,
+  getHubData,
+  updateSectionData,
+  getSectionData,
+  objectIdColumn
+};

--- a/app/widgets/CustomPopup.tsx
+++ b/app/widgets/CustomPopup.tsx
@@ -14,7 +14,7 @@ import SimpleFillSymbol = require('esri/symbols/SimpleFillSymbol');
 
 import RequestSet = require('app/RequestSet');
 import { circleAt } from 'app/latLong';
-import { getHubData, objectIdColumn } from 'app/data';
+import { getHubData } from 'app/data';
 import {
   spaceRendererInfo,
   attributeRow,
@@ -294,10 +294,14 @@ class CustomPopup extends declared(Widget) {
     */
     this.featureForUrl = featureForUrl;
 
+    /*
+      Use hardcoded OBJECTID_1 since layers may not be loaded yet so we cant
+      use objectIdField.
+    */
     this._queryAndUseFeatures(
       [featureForUrl.layer],
       {
-        where: `${objectIdColumn(featureForUrl.layer)} = '${featureForUrl.id}'`,
+        where: `OBJECTID_1 = '${featureForUrl.id}'`,
         outSpatialReference: new SpatialReference({'wkid': 4326}),
         // Ensure the query returns all fields, in particular the OBJECTID field
         outFields: ['*']

--- a/app/widgets/CustomPopup.tsx
+++ b/app/widgets/CustomPopup.tsx
@@ -14,7 +14,7 @@ import SimpleFillSymbol = require('esri/symbols/SimpleFillSymbol');
 
 import RequestSet = require('app/RequestSet');
 import { circleAt } from 'app/latLong';
-import { getHubData } from 'app/data';
+import { getHubData, objectIdColumn } from 'app/data';
 import {
   spaceRendererInfo,
   attributeRow,
@@ -294,15 +294,10 @@ class CustomPopup extends declared(Widget) {
     */
     this.featureForUrl = featureForUrl;
 
-    let idColumn = 'OBJECTID_1';
-    if (featureForUrl.layer === 'Campus Buildings') {
-      idColumn = 'OBJECTID';
-    }
-
     this._queryAndUseFeatures(
       [featureForUrl.layer],
       {
-        where: `${idColumn} = '${featureForUrl.id}'`,
+        where: `${objectIdColumn(featureForUrl.layer)} = '${featureForUrl.id}'`,
         outSpatialReference: new SpatialReference({'wkid': 4326}),
         // Ensure the query returns all fields, in particular the OBJECTID field
         outFields: ['*']
@@ -489,14 +484,9 @@ class CustomPopup extends declared(Widget) {
   private _updateFeatureForUrl(): void {
     if (this.page >= 0 && this.page < this.features.length) {
       const feature = this.features[this.page];
-      let id;
-      if (feature.layer.title === 'Campus Buildings') {
-        id = feature.attributes.OBJECTID;
-      } else {
-        id = feature.attributes.OBJECTID_1;
-      }
+
       this.featureForUrl = {
-        id: id,
+        id: Number(feature.getObjectId()),
         layer: feature.layer.title
       };
     /*
@@ -734,7 +724,8 @@ class CustomPopup extends declared(Widget) {
     }
 
     return (
-      <div key={feature.layer.title + feature.attributes.OBJECTID_1}>
+      <div
+        key={feature.layer.title + feature.getObjectId()}>
         {title}
         {noticeElements}
         <p><b>{feature.attributes.SectionAddress}</b></p>
@@ -759,7 +750,7 @@ class CustomPopup extends declared(Widget) {
   // Return a JSX element describing a building
   private _renderBuilding(feature: Graphic): JSX.Element {
     return (
-      <div key={feature.layer.title + feature.attributes.OBJECTID}>
+      <div key={feature.layer.title + feature.getObjectId()}>
         <h1>{featureTitle(feature)}</h1>
         <p><b>{feature.attributes.Address}</b></p>
         {
@@ -806,7 +797,7 @@ class CustomPopup extends declared(Widget) {
       );
     }
     return (
-      <div key={feature.layer.title + feature.attributes.OBJECTID_1}>
+      <div key={feature.layer.title + feature.getObjectId()}>
         <h1>{featureTitle(feature)}{icon}</h1>
         {reserved}{payment}{duration}
       </div>


### PR DESCRIPTION
closes #143 

Using the `getObjectId` method on features to get object id using the correct column for that layer. This applies except for one place in `openFromUrl` where the object id has to be hardcoded since the layers are not yet loaded. On the other hand we can just use `OBJECTID_1` now since every layer we use has it as a column.