### PR TITLE
Manually create tag before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ dist: focal
 language: node_js
 node_js: node
 script: yarn run compress
+branches:
+  only:
+    - master
 before_deploy:
   - git config --local user.name "UMass Transportation"
   - git config --local user.email "transportation-it@groups.umass.edu"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ dist: focal
 language: node_js
 node_js: node
 script: yarn run compress
+before_deploy:
+  - git config --local user.name "UMass Transportation"
+  - git config --local user.email "transportation-it@groups.umass.edu"
+  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
+  - git tag $TRAVIS_TAG
 deploy:
   edge: true
   provider: releases


### PR DESCRIPTION
I _think_ that this should result in an automated GH release again. Of course, I won't know until after this PR is merged. Instructions borrowed from:

https://docs.travis-ci.com/user/deployment-v2/providers/releases/#setting-the-tag-at-deployment-time