### PR TITLE
Still set a tag name in the rellease action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,13 @@ jobs:
       - name: Build and compress site
         run: yarn run compress
 
+      - name: Set release name
+        run: echo "RELEASE_TAG=$(date +'%Y%m%d%H%M%S')-${GITHUB_SHA::7}" >> $GITHUB_ENV
+
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.sha }}
+          tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true
           files: site.zip


### PR DESCRIPTION
So, apparently just using the SHA is fine for a draft release, but [not a real one](https://github.com/umts/GISMap/actions/runs/13681371054).